### PR TITLE
Add Session#userauth_password

### DIFF
--- a/ext/libssh_ruby/session.c
+++ b/ext/libssh_ruby/session.c
@@ -530,6 +530,23 @@ static VALUE m_userauth_none(VALUE self) {
 }
 
 /*
+ * @overload userauth_password
+ *  Try to authenticate through the "password" method.
+ *  @param [String] password
+ *  @return [Fixnum]
+ *  @see http://api.libssh.org/stable/group__libssh__auth.html ssh_userauth_password
+ */
+static VALUE m_userauth_password(VALUE self, VALUE password) {
+  SessionHolder *holder;
+  int rc;
+
+  TypedData_Get_Struct(self, SessionHolder, &session_type, holder);
+  rc = ssh_userauth_password(holder->session, NULL, StringValueCStr(password));
+  RAISE_IF_ERROR(rc);
+  return INT2FIX(rc);
+}
+
+/*
  * @overload userauth_list
  *  Get available authentication methods from the server.
  *  @return [Array<Symbol>]
@@ -699,6 +716,8 @@ void Init_libssh_session() {
 
   rb_define_method(rb_cLibSSHSession, "userauth_none",
                    RUBY_METHOD_FUNC(m_userauth_none), 0);
+  rb_define_method(rb_cLibSSHSession, "userauth_password",
+                   RUBY_METHOD_FUNC(m_userauth_password), 1);
   rb_define_method(rb_cLibSSHSession, "userauth_list",
                    RUBY_METHOD_FUNC(m_userauth_list), 0);
   rb_define_method(rb_cLibSSHSession, "userauth_publickey_auto",

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -87,6 +87,27 @@ RSpec.describe LibSSH::Session do
     end
   end
 
+  describe '#userauth_password' do
+    before do
+      session.host = SshHelper.host
+      session.port = DockerHelper.port
+      session.user = SshHelper.user
+      session.connect
+    end
+
+    context 'wrong password' do
+      it 'is denied' do
+        expect(session.userauth_password('12345')).to eq(LibSSH::AUTH_DENIED)
+      end
+    end
+
+    context 'with valid password' do
+      it 'access is granted' do
+        expect(session.userauth_password(SshHelper.password)).to eq(LibSSH::AUTH_SUCCESS)
+      end
+    end
+  end
+
   describe '#server_known' do
     before do
       session.host = SshHelper.host

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,10 @@ module SshHelper
       'alice'
     end
 
+    def password
+      'alice'
+    end
+
     def identity_path
       File.join(__dir__, 'id_ecdsa')
     end


### PR DESCRIPTION
This PR adds wrapper for libssh's [ssh_userauth_password](http://api.libssh.org/master/group__libssh__auth.html#ga50c0c150f8c4703e7ee49b3e3e3ca215) call. It enables libssh-ruby to be used with password login.

Supporting integration test cases are included.