### PR TITLE
Add support for libssh ≥ 0.8.0

### DIFF
--- a/ext/libssh_ruby/extconf.rb
+++ b/ext/libssh_ruby/extconf.rb
@@ -12,9 +12,9 @@ end
 unless have_library('ssh')
   abort 'Cannot find libssh'
 end
-unless have_library('ssh_threads')
-  abort 'Cannot find libssh_threads'
-end
+
+# libssh 0.8 has merged libssh_threads into libssh, so it’s not required.
+have_library('ssh_threads')
 
 have_const('SSH_KEYTYPE_ED25519', 'libssh/libssh.h')
 


### PR DESCRIPTION
This little change makes libssh-ruby build even with the latest version of libssh. The build generates lots of deprecation warnings from libssh, but the gem still works.

Fixes #3.